### PR TITLE
Convert vintrace/e2e-testing to GitHub Actions

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -1,0 +1,23 @@
+name: vintrace/e2e-testing
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  MAGNUM_USER: magnumuser
+  MAGNUM_PWD: "${{ secrets.MAGNUM_PWD }}"
+  VINTRACE_USER: sysadmin
+  VINTRACE_PWD: p
+  DEV_AWS_ACCESS_KEY_ID: "${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
+  DEV_AWS_SECRET_ACCESS_KEY: "${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
+  MYSQL_ROOT_PASSWORD: password
+jobs:
+  trigger_vintrace_core:
+    name: pipeline-vintrace-core
+    uses: "./.github/workflows/pipeline-vintrace-core.yml"
+  trigger_magnum:
+    name: pipeline-magnum
+    uses: "./.github/workflows/pipeline-magnum.yml"

--- a/.github/workflows/pipeline-magnum.yml
+++ b/.github/workflows/pipeline-magnum.yml
@@ -1,0 +1,13 @@
+# Environment variables defined in a calling workflow are not accessible to this reusable workflow. Refer to the documentation for further details on this limitation.
+name: pipeline-magnum
+on:
+  workflow_call:
+jobs:
+  magnum-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      ENABLE_MAGNUM_SERVICE: 'true'
+      TEST_TAGS: magnum
+    steps:
+    - uses: actions/checkout@v4.1.0

--- a/.github/workflows/pipeline-vintrace-core.yml
+++ b/.github/workflows/pipeline-vintrace-core.yml
@@ -1,0 +1,13 @@
+# Environment variables defined in a calling workflow are not accessible to this reusable workflow. Refer to the documentation for further details on this limitation.
+name: pipeline-vintrace-core
+on:
+  workflow_call:
+jobs:
+  vintrace-core-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      ENABLE_MAGNUM_SERVICE: 'false'
+      TEST_TAGS: vintrace & regression
+    steps:
+    - uses: actions/checkout@v4.1.0


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.vintrace.com/vintrace/e2e-testing) :tada:

## Manual steps

Perform the following steps to complete the migration:

### vintrace/e2e-testing
- [x] Ensure secret is available: `${{ secrets.MAGNUM_PWD }}`
- [x] Ensure secret is available: `${{ secrets.DEV_AWS_ACCESS_KEY_ID }}`
- [x] Ensure secret is available: `${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}`